### PR TITLE
outputPath append .exe in windows

### DIFF
--- a/qamel/cmd-build.go
+++ b/qamel/cmd-build.go
@@ -139,6 +139,9 @@ func buildHandler(cmd *cobra.Command, args []string) {
 	// Prepare default output path
 	if outputPath == "" {
 		outputPath = fp.Join(projectDir, fp.Base(projectDir))
+		if profile.OS == "windows" {
+			outputPath += ".exe"
+		}
 	}
 
 	// Run go build
@@ -229,3 +232,4 @@ func removeQamelFiles(rootDir string) error {
 
 	return err
 }
+


### PR DESCRIPTION
Default does not add `.exe` under windows. It cannot be run directly.
