### PR TITLE
Add arm64 support

### DIFF
--- a/internal/cmd/profile-setup.go
+++ b/internal/cmd/profile-setup.go
@@ -56,7 +56,7 @@ func profileSetupHandler(cmd *cobra.Command, args []string) {
 	// Fetch target architecture
 	fmt.Println()
 	fmt.Println("Please specify the target architecture for this profile. " +
-		`Possible values are "386" and "amd64".` + "\n" +
+		`Possible values are "386", "amd64", and "arm64".` + "\n" +
 		"Keep it empty to use your system architecture.")
 	fmt.Println()
 
@@ -68,7 +68,7 @@ func profileSetupHandler(cmd *cobra.Command, args []string) {
 	}
 
 	switch targetArch {
-	case "386", "amd64":
+	case "386", "amd64", "arm64":
 	default:
 		cRedBold.Printf("Architecture %s is not supported\n", targetArch)
 		os.Exit(1)

--- a/internal/generator/cgo.go
+++ b/internal/generator/cgo.go
@@ -136,6 +136,8 @@ func createCgoFlags(profile config.Profile, projectDir string) (string, error) {
     if _, ok := mapCompiler["EXPORT_ARCH_ARGS"]; ok {
         if profile.Arch == "amd64" {
             mapCompiler["EXPORT_ARCH_ARGS"] = "-arch x86_64"
+        } else if profile.Arch == "arm64" {
+            mapCompiler["EXPORT_ARCH_ARGS"] = "-arch aarch64"
         } else {
             mapCompiler["EXPORT_ARCH_ARGS"] = "-arch i386"
         }


### PR DESCRIPTION
This patch allows to build apps on arm64 platform. 
Tested on Pinephone (CPU Allwinner A64 ARM Quad core Cortex-A53, 64bit)  running Mobian. Which is bullseye/sid Debian based.

At this moment distro QT version is: 5.15.2

$ uname -a
Linux mobian 5.10-sunxi64 # 1 SMP PREEMPT Tue Dec 22 11:43:57 UTC 2020 aarch64 GNU/Linux
